### PR TITLE
Fix join BSS dropped command TODO

### DIFF
--- a/Driver/realtek-rtl8814au-dkms-kali-master/core/rtw_cmd.c
+++ b/Driver/realtek-rtl8814au-dkms-kali-master/core/rtw_cmd.c
@@ -5781,7 +5781,8 @@ void rtw_joinbss_cmd_callback(_adapter	*padapter,  struct cmd_obj *pcmd)
 	if (pcmd->res == H2C_DROPPED) {
 		/* TODO: cancel timer and do timeout handler directly... */
 		/* need to make timeout handlerOS independent */
-		_set_timer(&pmlmepriv->assoc_timer, 1);
+		_cancel_timer_ex(&pmlmepriv->assoc_timer);
+		rtw_join_timeout_handler(padapter);
 	} else if (pcmd->res != H2C_SUCCESS)
 		_set_timer(&pmlmepriv->assoc_timer, 1);
 


### PR DESCRIPTION
Resolved the TODO in `rtw_joinbss_cmd_callback` by explicitly canceling the association timer with `_cancel_timer_ex` and directly invoking `rtw_join_timeout_handler` when the command is dropped, replacing the workaround of setting the timer to 1ms.

---
*PR created automatically by Jules for task [16003765681641398247](https://jules.google.com/task/16003765681641398247) started by @mh37*