### PR TITLE
🔒 Fix: Prevent raw API response exposure in error logs

### DIFF
--- a/argos.py
+++ b/argos.py
@@ -156,8 +156,6 @@ class FrameHandler:
                 return locations
         except Exception:
             logger.exception(f"Error retrieving lat and long for {ssid}")
-            if 'data' in locals():
-                logger.error(f"Response: {data}")
 
         return locations
 


### PR DESCRIPTION
🎯 **What:** Removed the logging of raw API responses (`data`) in `argos.py`.
⚠️ **Risk:** The raw response from the WiGLE API could contain sensitive information (e.g. personal data, detailed error messages, or tokens) which, if logged during an error condition, could lead to information leakage and put the application or its users at risk.
🛡️ **Solution:** Removed the vulnerable lines `if 'data' in locals(): logger.error(f"Response: {data}")` to ensure raw responses are no longer exposed in error logs. The generic exception logging is retained to maintain visibility into errors without exposing sensitive content.

---
*PR created automatically by Jules for task [1312184428434722154](https://jules.google.com/task/1312184428434722154) started by @mh37*