### PR TITLE
🔒 Replace MD5 with SHA-256 for secure hashing

### DIFF
--- a/argos.py
+++ b/argos.py
@@ -126,7 +126,7 @@ class FrameHandler:
                         logger.info(f"Skipping captured frame. Signal strength {info['rssi']} is below the set minimum of {params.limitSignalStrength}")
                         return
                     identifier = f"{info['device']}{info['ssid']}"
-                    computed_hash = hashlib.md5(identifier.encode('utf-8')).hexdigest()
+                    computed_hash = hashlib.sha256(identifier.encode('utf-8')).hexdigest()
                     if not self.checkDuplicate(info, computed_hash):
                         self.addSeen(info, computed_hash)
                         self.executor.submit(self.process_probe, info, probeSSID)
@@ -165,7 +165,7 @@ class FrameHandler:
         try:
             if computed_hash is None:
                 identifier = f"{info['device']}{info['ssid']}"
-                computed_hash = hashlib.md5(identifier.encode('utf-8')).hexdigest()
+                computed_hash = hashlib.sha256(identifier.encode('utf-8')).hexdigest()
             self.seen.add(computed_hash)
         except Exception:
             logger.exception("Error. SSID was not stored successfully")
@@ -174,7 +174,7 @@ class FrameHandler:
         try:
             if computed_hash is None:
                 identifier = f"{info['device']}{info['ssid']}"
-                computed_hash = hashlib.md5(identifier.encode('utf-8')).hexdigest()
+                computed_hash = hashlib.sha256(identifier.encode('utf-8')).hexdigest()
             return computed_hash in self.seen
         except Exception:
             logger.exception("Error. SSID duplicate check failed")


### PR DESCRIPTION
🎯 **What:** Replaced the use of MD5 with SHA-256 for hashing device and SSID combinations in `argos.py`.
⚠️ **Risk:** MD5 is considered cryptographically weak and vulnerable to collision attacks. While the impact in this specific use case (generating unique identifiers for caching) might be lower, using weak cryptographic algorithms is a security vulnerability and bad practice.
🛡️ **Solution:** Swapped `hashlib.md5` for `hashlib.sha256`, which provides a much stronger cryptographic hash without noticeably impacting performance. Tested to ensure no regression in duplicates tracking.

---
*PR created automatically by Jules for task [6809215128454297153](https://jules.google.com/task/6809215128454297153) started by @mh37*