### PR TITLE
Fix: Disable Spatial Multiplexing Power Save Mode

### DIFF
--- a/Driver/realtek-rtl8814au-dkms-kali-master/core/rtw_mlme.c
+++ b/Driver/realtek-rtl8814au-dkms-kali-master/core/rtw_mlme.c
@@ -4622,7 +4622,7 @@ unsigned int rtw_restructure_ht_ie(_adapter *padapter, u8 *in_ie, u8 *out_ie, ui
 	}
 
 	/* todo: disable SM power save mode */
-	ht_capie.cap_info |= IEEE80211_HT_CAP_SM_PS;
+	/* ht_capie.cap_info |= IEEE80211_HT_CAP_SM_PS; */
 
 	/* RX LDPC */
 	if (TEST_FLAG(phtpriv->ldpc_cap, LDPC_HT_ENABLE_RX)) {


### PR DESCRIPTION
Removed the `IEEE80211_HT_CAP_SM_PS` flag from `ht_capie.cap_info` in `rtw_mlme.c` to disable Spatial Multiplexing Power Save mode as per the TODO.

---
*PR created automatically by Jules for task [10389877127387261201](https://jules.google.com/task/10389877127387261201) started by @mh37*