### PR TITLE
🧹 [Code Health] Remove unused 'os' import in argos.py

### DIFF
--- a/argos.py
+++ b/argos.py
@@ -8,7 +8,6 @@ import itertools
 import hashlib
 import urllib.parse
 import subprocess
-import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import List, Dict, Optional, Any, Set


### PR DESCRIPTION
🎯 **What:** Removed unused `import os` line from `argos.py`.
💡 **Why:** To improve code health and maintainability by removing unnecessary/unused modules, eliminating namespace pollution and addressing linter/hygiene issues.
✅ **Verification:** Verified by inspecting the file manually and running the unit tests `python -m unittest test_argos.py`, all of which passed.
✨ **Result:** Improved codebase cleanliness and readability without impacting the application's runtime behavior.

---
*PR created automatically by Jules for task [13081245113936840230](https://jules.google.com/task/13081245113936840230) started by @mh37*