### PR TITLE
🧹 Remove unused hopChannel function

### DIFF
--- a/argos.py
+++ b/argos.py
@@ -34,9 +34,6 @@ try:
 except FileNotFoundError:
     logger.error("vendors.txt not found. Vendor lookup will be disabled.")
 
-#in case you need to hop through channels (2.4 and 5 GHz Europe)
-channels = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 64, 68, 96, 100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124, 126, 128, 132, 134, 136, 138, 140, 142, 144, 149, 151, 153, 155, 157, 159, 161, 165, 167, 169, 171, 173]
-
 class LazyDecoder(json.JSONDecoder):
     def decode(self, s, **kwargs):
         regex_replacements = [
@@ -201,15 +198,6 @@ def start_sniffer(config: Dict[str, Any], interface: str, write_file: Optional[s
 
     sniff(iface=interface, prn=frameHandler.handler, store=0)
     logger.info("Sniffer stopped.")
-
-def hopChannel():
-    for channel in itertools.cycle(channels):
-        try:
-            subprocess.run(["iwconfig", params.interface, "channel", str(channel)], check=False)
-        except Exception:
-            logger.exception("Error hopping channel")
-        import time
-        time.sleep(3)
 
 
 def getConfig() -> Dict[str, Any]:


### PR DESCRIPTION
🎯 **What:** Removed the `hopChannel` function and the `channels` list from `argos.py`.
💡 **Why:** The `hopChannel` function was dead code, completely unreferenced in the codebase. Removing it reduces code bloat and improves maintainability. The `channels` list was exclusively used by this function and was therefore also dead data.
✅ **Verification:** Verified by running the unit test suite (`python3 -m unittest discover -v`), which successfully passed. Also ran `python3 -m py_compile argos.py` to ensure there are no syntax errors introduced. Code review was passed.
✨ **Result:** Cleaned up unused functions and variables, reducing overall code bloat and improving readability.

---
*PR created automatically by Jules for task [122644067153775627](https://jules.google.com/task/122644067153775627) started by @mh37*