### PR TITLE
Optimize WMM parameter set updates

### DIFF
--- a/Driver/realtek-rtl8814au-dkms-kali-master/core/rtw_wlan_util.c
+++ b/Driver/realtek-rtl8814au-dkms-kali-master/core/rtw_wlan_util.c
@@ -1497,16 +1497,22 @@ int WMM_param_handler(_adapter *padapter, PNDIS_802_11_VARIABLE_IEs	pIE)
 	struct mlme_priv	*pmlmepriv = &(padapter->mlmepriv);
 	struct mlme_ext_priv	*pmlmeext = &padapter->mlmeextpriv;
 	struct mlme_ext_info	*pmlmeinfo = &(pmlmeext->mlmext_info);
+	u8 new_count, old_count;
 
 	if (pmlmepriv->qospriv.qos_option == 0) {
 		pmlmeinfo->WMM_enable = 0;
 		return _FALSE;
 	}
 
-	if (_rtw_memcmp(&(pmlmeinfo->WMM_param), (pIE->data + 6), sizeof(struct WMM_para_element)))
-		return _FALSE;
-	else
-		_rtw_memcpy(&(pmlmeinfo->WMM_param), (pIE->data + 6), sizeof(struct WMM_para_element));
+	new_count = ((struct WMM_para_element *)(pIE->data + 6))->QoS_info & 0x0F;
+	old_count = pmlmeinfo->WMM_param.QoS_info & 0x0F;
+
+	if (pmlmeinfo->WMM_enable && new_count == old_count) {
+		if (_rtw_memcmp(&(pmlmeinfo->WMM_param), (pIE->data + 6), sizeof(struct WMM_para_element)))
+			return _FALSE;
+	}
+
+	_rtw_memcpy(&(pmlmeinfo->WMM_param), (pIE->data + 6), sizeof(struct WMM_para_element));
 	pmlmeinfo->WMM_enable = 1;
 	return _TRUE;
 


### PR DESCRIPTION
Update `WMM_param_handler` in `rtw_wlan_util.c` to parse the parameter set count and use it to skip unnecessary updates. It still relies on the memory comparison as a fallback to ensure state synchronization for APs that don't increment the count.

---
*PR created automatically by Jules for task [11066863884156142378](https://jules.google.com/task/11066863884156142378) started by @mh37*