### PR TITLE
Verify AP 40MHz capability for auto scan

### DIFF
--- a/Driver/realtek-rtl8814au-dkms-kali-master/core/rtw_mlme.c
+++ b/Driver/realtek-rtl8814au-dkms-kali-master/core/rtw_mlme.c
@@ -3079,15 +3079,26 @@ void rtw_mlme_reset_auto_scan_int(_adapter *adapter, u8 *reason)
 #endif
 	u8 u_ch;
 	u32 interval_ms = 0xffffffff; /* 0xffffffff: special value to make min() works well, also means no auto scan */
+	sint ht_ielen = 0;
+	u8 *pht_cap_ie = NULL;
+	u8 ap_bw_40m = _FALSE;
 
 	*reason = RTW_AUTO_SCAN_REASON_UNSPECIFIED;
 	rtw_mi_get_ch_setting_union(adapter, &u_ch, NULL, NULL);
+
+	if (is_client_associated_to_ap(adapter) == _TRUE) {
+		pht_cap_ie = rtw_get_ie(BSS_EX_TLV_IES(&adapter->mlmepriv.cur_network.network), _HT_CAPABILITY_IE_, &ht_ielen, BSS_EX_TLV_IES_LEN(&adapter->mlmepriv.cur_network.network));
+		if (pht_cap_ie && ht_ielen > 0) {
+			if (GET_HT_CAP_ELE_CHL_WIDTH(pht_cap_ie + 2))
+				ap_bw_40m = _TRUE;
+		}
+	}
 
 	if (hal_chk_bw_cap(adapter, BW_CAP_40M)
 		&& is_client_associated_to_ap(adapter) == _TRUE
 		&& u_ch >= 1 && u_ch <= 14
 		&& adapter->registrypriv.wifi_spec
-		/* TODO: AP Connected is 40MHz capability? */
+		&& ap_bw_40m == _TRUE
 	) {
 		interval_ms = rtw_min(interval_ms, 60 * 1000);
 		*reason |= RTW_AUTO_SCAN_REASON_2040_BSS;


### PR DESCRIPTION
The auto scan logic previously assumed that if the client supports 40MHz, it should trigger a 20/40 BSS scan. However, it forgot to check if the currently connected AP also supports 40MHz.

This change adds the missing check:
1. It uses `rtw_get_ie` to extract the `_HT_CAPABILITY_IE_` from the network descriptor.
2. It evaluates `GET_HT_CAP_ELE_CHL_WIDTH` on the capability info to determine 40MHz support.
3. Only triggers the 20/40 scan if the AP actually supports it.

---
*PR created automatically by Jules for task [14035339786299922782](https://jules.google.com/task/14035339786299922782) started by @mh37*