### PR TITLE
🔒 Fix CSWSH vulnerability in WebSocketServer origin check

### DIFF
--- a/argos.py
+++ b/argos.py
@@ -49,19 +49,16 @@ class LazyDecoder(json.JSONDecoder):
 class WebSocketServer(websocket.WebSocketHandler):
     clients: Set['WebSocketServer'] = set()
 
-    def check_origin(self, origin: str) -> bool:
-        return True
-
     def open(self):
         logger.info("Client connected")
-        WebSocketSever.clients.add(self)
+        WebSocketServer.clients.add(self)
 
     def on_message(self, message: str):
         logger.info(f"Message: {message}")
 
     def on_close(self):
         logger.info("Connection terminated.")
-        WebSocketSever.clients.remove(self)
+        WebSocketServer.clients.remove(self)
 
     @classmethod
     def broadcast(cls, message: str):

--- a/test_websocket.py
+++ b/test_websocket.py
@@ -1,0 +1,45 @@
+import tornado.testing
+import tornado.web
+import tornado.websocket
+import urllib.parse
+from tornado.httpclient import HTTPRequest
+from argos import WebSocketServer, getConfig
+
+class TestWebSocketOrigin(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return tornado.web.Application([
+            (r'/ws', WebSocketServer),
+        ])
+
+    @tornado.testing.gen_test
+    async def test_websocket_origin_allowed(self):
+        ws_url = "ws://127.0.0.1:%d/ws" % self.get_http_port()
+        # Tornado checks if the origin domain matches the host header.
+        request = HTTPRequest(
+            url=ws_url,
+            headers={"Origin": "http://127.0.0.1:%d" % self.get_http_port(),
+                     "Host": "127.0.0.1:%d" % self.get_http_port()}
+        )
+        try:
+            ws = await tornado.websocket.websocket_connect(request)
+            self.assertTrue(True)
+            ws.close()
+        except Exception as e:
+            self.fail(f"Connection failed: {e}")
+
+    @tornado.testing.gen_test
+    async def test_websocket_origin_rejected(self):
+        ws_url = "ws://127.0.0.1:%d/ws" % self.get_http_port()
+        request = HTTPRequest(
+            url=ws_url,
+            headers={"Origin": "http://evil.com",
+                     "Host": "127.0.0.1:%d" % self.get_http_port()}
+        )
+        try:
+            ws = await tornado.websocket.websocket_connect(request)
+            self.fail("Connection should have been rejected")
+        except Exception as e:
+            self.assertEqual(e.code, 403)
+
+if __name__ == '__main__':
+    tornado.testing.main()


### PR DESCRIPTION
🎯 **What:** An overly permissive WebSocket origin vulnerability where `check_origin` returned `True` for any domain.
⚠️ **Risk:** Allowed Cross-Site WebSocket Hijacking (CSWSH), potentially exposing client connections and data broadcasted via the WebSocket to malicious third-party websites.
🛡️ **Solution:** Removed the `check_origin` override completely, falling back to Tornado's default secure policy which automatically verifies that the `Origin` matches the `Host`. Additionally, corrected a typo (`WebSocketSever` to `WebSocketServer`) that threw exceptions in `open` and `on_close` routines, and added comprehensive WebSocket tests verifying expected HTTP 403 blocks for unauthorized origins.

---
*PR created automatically by Jules for task [6866067647649599023](https://jules.google.com/task/6866067647649599023) started by @mh37*